### PR TITLE
Replace menu with Bootstrap navbar

### DIFF
--- a/ProyectoFinal/web/index.html
+++ b/ProyectoFinal/web/index.html
@@ -4,36 +4,45 @@
     <meta charset="UTF-8">
 <title>Trabajo Final </title>
 <link href="style.css" rel="stylesheet" type="text/css">
-
+<link href="bootstrap.min.css" rel="stylesheet">
 
 </head>
 <body>
-    <div id="header">
-
-<ul class="nav">
-        <li><a href="">Inicio</a></li>
-        <li><a href="">Servicios</a><ul>
-            <li><a href="">Venta</a></li>
-            <li><a href="">Colocación</a></li>
-            <li><a href="">Reparación</a></li>
-            <li><a href="">Pedidos</a>
-            <ul>   
-                <li><a href="login.html">Ingresar</a></li> 			
-                <li><a href="consultarpedidos.html">Consultar</a></li> 
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+        <a class="navbar-brand" href="#">Inicio</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse justify-content-end" id="navbarNavDropdown">
+            <ul class="navbar-nav">
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="serviciosDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Servicios</a>
+                    <div class="dropdown-menu" aria-labelledby="serviciosDropdown">
+                        <a class="dropdown-item" href="#">Venta</a>
+                        <a class="dropdown-item" href="#">Colocación</a>
+                        <a class="dropdown-item" href="#">Reparación</a>
+                        <div class="dropdown-divider"></div>
+                        <div class="dropdown dropright">
+                            <a class="dropdown-item dropdown-toggle" href="#" id="pedidosDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Pedidos</a>
+                            <div class="dropdown-menu" aria-labelledby="pedidosDropdown">
+                                <a class="dropdown-item" href="login.html">Ingresar</a>
+                                <a class="dropdown-item" href="consultarpedidos.html">Consultar</a>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="acercaDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Acerca de</a>
+                    <div class="dropdown-menu" aria-labelledby="acercaDropdown">
+                        <a class="dropdown-item" href="#">Nosotros</a>
+                        <a class="dropdown-item" href="#">Nuestra Misión</a>
+                        <a class="dropdown-item" href="#">Historia</a>
+                    </div>
+                </li>
+                <li class="nav-item"><a class="nav-link" href="#">Contacto</a></li>
             </ul>
-            </li>        
-        </ul></li>
-
-        <li><a href="">Acerca de </a><ul>
-            <li><a href="">Nosotros</a></li>
-            <li><a href="">Nuestra Misión</a></li>
-            <li><a href="">Historia</a></li>        
-        </ul></li>
-        <li><a href="">Contacto</a></li>
-
-
-</ul>
-</div>
+        </div>
+    </nav>
 
 <div class="imagen">
 <hr>
@@ -82,5 +91,8 @@ Y al mismo tiempo que la producción aumentaba, se hacía necesario invertir en:
     El Clúster Logístico de Cataluña ya ha tenido un reconocimiento como cluster en el ámbito europeo, con la certificación categoría bronce que otorga la ESCA (European Secretariat for Cluster Analysis). Asimismo, es miembro de la asociación europea ALICE (Alliance for Logistics Innovation through collaboration in Europe).
 </p>
 </div>
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use Bootstrap navbar instead of custom menu
- add Bootstrap scripts for dropdown functionality

## Testing
- `ant -noinput -f ProyectoFinal/build.xml` *(fails: ant not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f5addc100832faca458504b18ecf4