### PR TITLE
Allow login by username

### DIFF
--- a/ProyectoFinal/src/java/UsuarioDAO.java
+++ b/ProyectoFinal/src/java/UsuarioDAO.java
@@ -10,9 +10,9 @@ public class UsuarioDAO {
     }
     
     public ResultSet validarUsuario(String email, String password){
-        String sql = "SELECT * FROM usuario WHERE email = ? AND contraseña = ?";
+        String sql = "SELECT * FROM usuario WHERE (email = ? OR nombre_usuario = ?) AND contraseña = ?";
         String hashed = hashPassword(password);
-        return conexion.consultaSQL(sql, email, hashed);
+        return conexion.consultaSQL(sql, email, email, hashed);
     }
     
     public void cerrar(){

--- a/ProyectoFinal/web/login.html
+++ b/ProyectoFinal/web/login.html
@@ -37,7 +37,7 @@
   <img class="mb-4" src="logo.jpg" alt="" width="72" height="72">
   <h1 class="h3 mb-3 font-weight-normal">Ingresar al sistema</h1>
   <label for="inputEmail" class="sr-only">Email / Usuario</label>
-  <input type="email" id="inputEmail" name="inputEmail" class="form-control" placeholder="Email address" required autofocus>
+  <input type="text" id="inputEmail" name="inputEmail" class="form-control" placeholder="Email address" required autofocus>
   <label for="inputPassword" class="sr-only">Clave</label>
   <input type="password" id="inputPassword" name="inputPassword" class="form-control" placeholder="Password" required>
   <div class="checkbox mb-3">


### PR DESCRIPTION
## Summary
- update login form to accept text instead of email
- support login with username or email in `validarUsuario`

## Testing
- `git status --short`
- `ant -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5e0f9870832faba451a6a188e08b